### PR TITLE
Fixes and updates, notably for cambl and cl-ledger

### DIFF
--- a/periods.lisp
+++ b/periods.lisp
@@ -520,7 +520,7 @@ If days has been added before years, the result would have been
 	   (zerop (duration-minutes duration)))
       (multiple-value-bind (quotient remainder)
 	  (floor (funcall (if reverse #'- #'+)
-			  (+ (* (unix-to-timestamp fixed-time) 1000000000)
+			  (+ (* (timestamp-to-unix fixed-time) 1000000000)
 			     (nsec-of fixed-time))
 			  (+ (* (duration-seconds duration) 1000000000)
 			     (* (duration-milliseconds duration) 1000000)

--- a/strptime.lisp
+++ b/strptime.lisp
@@ -273,7 +273,7 @@
 		    (format out "~2,'0D" second))
 
 		   ((char= c #\s)	; seconds since Epoch, UTC (unix time)
-		    (format out "~D" (local-time:unix-to-timestamp fixed-time)))
+		    (format out "~D" (local-time:timestamp-to-unix fixed-time)))
 
 		   ((char= c #\T)	; equiv: %H:%M:%S
 		    (princ (strftime fixed-time :format "%H:%M:%S") out))


### PR DESCRIPTION
Hi,

This is indirectly related to https://github.com/jwiegley/red-black/issues/2. While modifying the cambl package to use cl-containers instead of red-black, I felt the need to modify the periods package.

 - The PERIODS packages was recently updated to take into account new naming conventions in LOCAL-TIME; however, there were two mis-corrections where UNIX-TIME was replaced erroneously by UNIX-TO-TIMESTAMP.

- The second commit introduces a macro that is related to time ranges and simplify some operations in CAMBL and CL-LEDGER

Regards