### PR TITLE
Fixes for fixed-time parsing

### DIFF
--- a/parser.lisp
+++ b/parser.lisp
@@ -12,6 +12,11 @@
 (defparameter *token-stack* nil)
 (defparameter *parser-readtable* (copy-readtable nil))
 
+(defun ignore-character (stream char)
+  (declare (ignore stream))
+  (declare (ignore char))
+  (values))
+
 (set-macro-character #\, #'ignore-character nil *parser-readtable*)
 (set-macro-character #\/ #'ignore-character nil *parser-readtable*)
 


### PR DESCRIPTION
The read-integer function was silently eating spaces and failing on colons.
Now, "2019/01/02 12:34:56" can be parsed correctly.