### PR TITLE
Periods-series was fixed by using internal time-generator from periods package.

### DIFF
--- a/periods-series.lisp
+++ b/periods-series.lisp
@@ -2,6 +2,9 @@
 
 (defpackage :periods-series
      (:use :common-lisp :periods :series)
+     ;; This symbol is not external in :periods package
+     (:import-from #:periods
+                   #:time-generator)
      (:export scan-times
               scan-relative-times
               scan-time-period


### PR DESCRIPTION
Without this patch, functions from the periods-series package don't work. They were broken by this commit: https://github.com/jwiegley/periods/commit/e649722416e0a26d22b81232dcd2c2dc8b3f7134