### PR TITLE
Correctly subtract hour-based durations crossing midnight

### DIFF
--- a/periods.lisp
+++ b/periods.lisp
@@ -386,7 +386,7 @@ not just durations."
 		(if (minusp remainder)
 		    (progn
 		      (skip-day -1)
-		      (setf hh 59)
+		      (setf hh 23)
 		      (skip-hour (1+ remainder)))
 		    (incf hh skip)))
 	      (if (plusp skip)


### PR DESCRIPTION
add-time/subtract-time can produce hour components greater than 23 when subtracting across midnight.

Expected Behavior:
```lisp
CL-USER>(local-time:now)
@2022-08-17T17:55:15.704169+02:00
CL-USER> (periods:subtract-time * (periods:duration :hours 24))
@2022-08-16T17:55:15.704169+02:00
```

Actual Behaviour:
```
The time specification is invalid
   [Condition of type LOCAL-TIME::INVALID-TIME-SPECIFICATION]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] abort thread (#<THREAD "repl-thread" RUNNING {1001988003}>)

Backtrace:
  0: (LOCAL-TIME::ENCODE-TIMESTAMP-INTO-VALUES 704169000 15 55 53 16 8 2022 :TIMEZONE #<LOCAL-TIME::TIMEZONE LMT CEST CET CEST CET CEMT CEMT CEST CET> :OFFSET NIL)
  1: (LOCAL-TIME:ENCODE-TIMESTAMP 704169000 15 55 53 16 8 2022 :TIMEZONE NIL :OFFSET NIL :INTO NIL)
      Locals:
        #:.DEFAULTING-TEMP. = NIL
        #:.DEFAULTING-TEMP.#1 = NIL
        DAY = 16
        HOUR = 53
        MINUTE = 55
        MONTH = 8
        #:N-SUPPLIED-0 = 0
        NSEC = 704169000
        OFFSET = NIL
        SEC = 15
        YEAR = 2022
  2: (PERIODS:ADD-TIME @2022-08-17T17:55:15.704169+02:00 #S(PERIODS:DURATION :YEARS 0 :MONTHS 0 :DAYS 0 :HOURS 24 :MINUTES 0 :SECONDS 0 ...) :REVERSE T)
  3: (PERIODS:SUBTRACT-TIME @2022-08-17T17:55:15.704169+02:00 #S(PERIODS:DURATION :YEARS 0 :MONTHS 0 :DAYS 0 :HOURS 24 :MINUTES 0 :SECONDS 0 ...))
  4: (SB-INT:SIMPLE-EVAL-IN-LEXENV (PERIODS:SUBTRACT-TIME * (PERIODS:DURATION :HOURS 24)) #<NULL-LEXENV>)
  5: (EVAL (PERIODS:SUBTRACT-TIME * (PERIODS:DURATION :HOURS 24)))
 --more--
```

As far as I can tell it works correctly now.